### PR TITLE
Modify CMakeLists & Add script as TLDR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.vscode/
+.envrc
+build/
+sandbox/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,9 @@
 cmake_minimum_required(VERSION 3.4.3)
+project(llvm-block)
 
 set(LLVM_ROOT "" CACHE PATH "Root of LLVM install.")
 
 list(APPEND CMAKE_PREFIX_PATH
      "${LLVM_ROOT}/lib/cmake")
-find_package(LLVM REQUIRED CONFIG)
-
-list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
-include(HandleLLVMOptions) # load additional config
-include(AddLLVM) # used to add our own modules
-
-add_definitions(${LLVM_DEFINITIONS})
-include_directories(${LLVM_INCLUDE_DIRS})
 
 add_subdirectory(llvm-block)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ sudo ./llvm.sh <version number>
     cmake .. -DLLVM_ROOT=<path to llvm source root>
     make llvm-block
     ./llvm-block/llvm-block <before> <after>
-    
+
 ### Quick Commands
     clang -O0 -g -Xclang -disable-O0-optnone -emit-llvm -S *.c
     llvm-link *.ll -S -o beforeg.ll
@@ -37,3 +37,10 @@ sudo ./llvm.sh <version number>
     mv .*.dot before
     opt -dot-cfg after.ll
     mv .*.dot after
+
+### Short script
+If you are too bothered to run the commands above, simply run `run-llvm-block.sh` with the following instructions.
+
+1. First add a `*.c` file to any directory, say you have `foo/a.c`.
+
+2. Then simply run `bash run-llvm-block.sh foo` (checkout the code for more options if you are on MacOS).

--- a/llvm-block/CMakeLists.txt
+++ b/llvm-block/CMakeLists.txt
@@ -1,19 +1,18 @@
 cmake_minimum_required(VERSION 3.4.3)
 
+find_package(LLVM REQUIRED CONFIG)
+include_directories(${LLVM_INCLUDE_DIRS})
+add_definitions(${LLVM_DEFINITIONS})
 
-set(LLVM_LINK_COMPONENTS
+add_executable(llvm-block
+  llvm-block.cpp
+  table.cpp
+)
+
+llvm_map_components_to_libnames(llvm_libs
   Core
   IRReader
   Support
-  )
+)
 
-add_llvm_tool(llvm-block
-  llvm-block.cpp
-  table.cpp
-
-
-  DEPENDS
-  intrinsics_gen
-  )
-
-export_executable_symbols(llvm-block)
+target_link_libraries(llvm-block ${llvm_libs})

--- a/run-llvm-block.sh
+++ b/run-llvm-block.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# Check if $LLVM_BIN_PATH is set
+if [ -z "$LLVM_BIN_PATH" ]; then
+    echo "LLVM_BIN_PATH is not set"
+    exit 1
+fi
+
+MACOS_FLAG=false
+OPT_LEVEL=0
+LLVM_PASS="mem2reg"  # Default pass
+
+# Parse command line arguments
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --macos)
+            MACOS_FLAG=true
+            shift
+            ;;
+        --opt-level=*)
+            OPT_LEVEL="${1#*=}"
+            shift
+            ;;
+        --pass=*)
+            LLVM_PASS="${1#*=}"
+            shift
+            ;;
+        *)
+            if [ -z "$TARGET_DIR" ]; then
+                TARGET_DIR="$1"
+            else
+                echo "Error: Unexpected argument: $1"
+                echo "Usage: $0 [--macos] [--opt-level=N] [--pass=<llvm-pass>] <target_directory>"
+                exit 1
+            fi
+            shift
+            ;;
+    esac
+done
+
+# Check if target directory is provided
+if [ -z "$TARGET_DIR" ]; then
+    echo "Usage: $0 [--macos] [--opt-level=<opt-level>] [--pass=<llvm-pass>] <target_directory>"
+    exit 1
+fi
+
+LLVM_BLOCK_PATH="$(pwd)/build/llvm-block"
+
+# Get macOS SDK path
+if [ "$MACOS_FLAG" = true ]; then
+    MACOS_SDK_PATH=$(xcrun --sdk macosx --show-sdk-path)
+else
+    MACOS_SDK_PATH=""
+fi
+
+# Change to target directory
+echo "Changing to target directory... $TARGET_DIR"
+cd "$TARGET_DIR"
+
+# Compile C files to LLVM IR
+echo "Compiling C files to LLVM IR..."
+
+if [ "$MACOS_FLAG" = true ]; then
+    "$LLVM_BIN_PATH/clang" -O$OPT_LEVEL -g -Xclang -disable-O0-optnone -emit-llvm -S *.c \
+      -isysroot "$MACOS_SDK_PATH"
+else
+    "$LLVM_BIN_PATH/clang" -O$OPT_LEVEL -g -Xclang -disable-O0-optnone -emit-llvm -S *.c
+fi
+
+# Link LLVM IR files
+"$LLVM_BIN_PATH/llvm-link" *.ll -S -o beforeg.ll
+
+# Apply transformation pass
+"$LLVM_BIN_PATH/opt" beforeg.ll -S -$LLVM_PASS -o afterg.ll
+
+# Run llvm-block
+"$LLVM_BLOCK_PATH/llvm-block" beforeg.ll afterg.ll 2> output
+
+# Strip debug info
+"$LLVM_BIN_PATH/opt" --strip-debug -S beforeg.ll -o before.ll
+"$LLVM_BIN_PATH/opt" --strip-debug -S afterg.ll -o after.ll
+
+# print log
+echo "Generating CFGs..."
+
+# Generate CFGs
+mkdir -p before after
+"$LLVM_BIN_PATH/opt" -dot-cfg -f before.ll
+mv .*.dot before/
+"$LLVM_BIN_PATH/opt" -dot-cfg -f after.ll
+mv .*.dot after/


### PR DESCRIPTION
This PR includes two main improvements, along with some utility addtions (e.g., adding a .gitignore file):

1. Adds a script to run llvm-block.

2. Refactors the CMakeLists.txt to use standard CMake constructs instead of LLVM-internal macros, enabling standalone builds outside the LLVM source tree.

This PR will be merged using `rebase and merge`.